### PR TITLE
Fixes: Cannot call method 'trim' of null

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -168,7 +168,10 @@ function convert (version, callback) {
       var code = famous[key];
       var depth = key.split(path.sep).length - 1;
       var resolvePath = makeResolvePathFn(depth);
-      memo[key] = convertAMDToCommonJS(code, codeStyleOptions, resolvePath).trim('\n');
+      var upgradified = convertAMDToCommonJS(code, codeStyleOptions, resolvePath);
+      if (upgradified) {
+        memo[key] = upgradified.trim('\n');
+      }
       return memo;
     }, {});
 


### PR DESCRIPTION
Fixes the first issue reported here: https://github.com/FamousTools/famous-dist-generator/issues/4
- Fixes path issue in isDesiredFile by replacing `/` with `path.sep`
- Adds logic to check if `convertAMDToCommonJS` returns `null` before adding it to `memo`
