### PR TITLE
Remove 'famous' namespace

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -303,7 +303,6 @@ function writeRequireJS (version, destination, minify, callback) {
   }, function(err, famousPath) {
     if (err) { return callback(err); }
     var modules = [];
-    var namespace = 'famous';
     var finder = findit(famousPath);
     finder.on('directory', function (dir, stat, stop) {
         var base = path.basename(dir);
@@ -316,7 +315,7 @@ function writeRequireJS (version, destination, minify, callback) {
             var base = path.basename(file, '.js');
             if (base === 'Gruntfile') { return; }
             var relativePath = path.relative(famousPath, path.dirname(file));
-            var module = path.join(namespace, relativePath, base);
+            var module = path.join(relativePath, base);
             modules.push(module);
         }
     });


### PR DESCRIPTION
Removes the namespace prefix on all modules.

Fix for #7 