### PR TITLE
Replace windows path separator with UNIX friendly separator

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -317,6 +317,7 @@ function writeRequireJS (version, destination, minify, callback) {
             if (base === 'Gruntfile') { return; }
             var relativePath = path.relative(famousPath, path.dirname(file));
             var module = path.join(namespace, relativePath, base);
+            module = module.split('\\').join('/');
             modules.push(module);
         }
     });


### PR DESCRIPTION
Convert all windows separators to UNIX friendly separators. 

Fix for #8 